### PR TITLE
Added "decode until found" for returning parsed scte objects. Added multicast example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     * [Time Signal Placement Opportunity End](https://github.com/futzu/SCTE35-threefive/blob/master/examples/Time_Signal-Placement_Opportunity_End.py)
     * [Time Signal Program Overlap ](https://github.com/futzu/SCTE35-threefive/blob/master/examples/Time_Signal-Program_Overlap.py)
     * [Time Signal Program Start End](https://github.com/futzu/SCTE35-threefive/blob/master/examples/Time_Signal-Program_Start_End.py)
+    * [Parsing SCTE-35 from a multicast source](https://github.com/futzu/SCTE35-threefive/blob/master/examples/multicast/ts_scte_parser.py)
 
 * [__Easy threefive__](#easy-threefive)
   *   [The __decode__ Function](#the-decode-function)

--- a/examples/multicast/ts_scte_parser.py
+++ b/examples/multicast/ts_scte_parser.py
@@ -1,0 +1,49 @@
+import socket
+import threefive
+import struct
+import io
+
+class TSScte35Parser():
+    # TODO: Add unicast / multicast flag or auto-detect based on IP CIDR
+    def __init__(self, mcast_ip, if_ip="0.0.0.0", hostname="0.0.0.0", port=9000):
+        self.HOST = hostname
+        self.PORT = port
+        self.MCAST_IP = mcast_ip
+        self.IF_IP = if_ip
+
+
+    def run(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock:
+            self.set_socket_options(sock)
+            sock.bind((self.HOST, self.PORT))
+
+            with sock.makefile(mode="b") as socket_file:
+                while True:
+                    try:
+                        scte = threefive.StreamPlus(socket_file).decode_until_found()
+                        for scte_obj in scte:
+                            print("Found SCTE-35:", scte_obj)
+                            print("--------------------------------")
+                    except Exception as e:
+                        print("ERROR while decoding TS:", e)
+                        pass
+
+
+    def set_socket_options(self, sock):
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, socket.inet_aton(self.MCAST_IP)+socket.inet_aton(self.HOST))
+        # TODO: Below is used to specify a specific interface to use for MC subscription
+
+        # group_bin =  socket.inet_aton(self.MCAST_IP)
+        # local_bin =  socket.inet_aton(self.IF_IP) # Which interface to IGMP join on
+
+        # sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, local_bin)
+
+        # mreq = struct.pack("4sL", group_bin, socket.INADDR_ANY)
+        # # mreq = group_bin + socket.inet_aton('6.116.252.42') # Possible IGMPv3 method
+
+        # sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+
+if __name__ == "__main__":
+    test = TSScte35Parser(mcast_ip="239.0.0.1")
+    test.run()

--- a/threefive/streamplus.py
+++ b/threefive/streamplus.py
@@ -52,6 +52,37 @@ class StreamPlus(Stream):
             tf = Splice(packet,packet_data)
             tf.show()
 
+    def parse_packet_return(self, packet):
+        two_bytes = int.from_bytes(packet[1:3],byteorder='big')
+        pid = hex(two_bytes & 0x1fff)
+        if (two_bytes >> 14 & 0x1):
+            self.parse_pusi(packet[4:20])
+        if self.chk_magic(packet[:20]):
+            packet_data = {'pid':pid,'pts':self.PTS}
+            tf = Splice(packet,packet_data)
+            return tf.get()
     
     def parse(self,packets):
         [self.parse_packet(packet) for packet in packets]
+
+    def parse_return(self,packets):
+        return [self.parse_packet_return(packet) for packet in packets]
+
+    def decode_until_found(self):
+        '''
+        Split data into 188 byte packets
+        '''
+        pkt_sz = 188  # mpegts packet size
+        pkt_ct = 384 # packet count
+        chunk_sz = pkt_sz * pkt_ct
+        while self.tsdata:
+            first_byte = self.tsdata.read(1)
+            if not first_byte: break
+            if first_byte == self.sync_byte:
+                chunk = first_byte + self.tsdata.read(chunk_sz -1)
+                if not chunk: break
+                parsed_packets = self.parse_return([chunk[i:i+pkt_sz]
+                        for i in range(0,len(chunk),pkt_sz)])
+                filtered_packets = list(filter(lambda var: var is not None, parsed_packets))
+                if filtered_packets:
+                    return filtered_packets


### PR DESCRIPTION
The current streamplus.py only allows for decoding and printing. I added a few methods that allow for decoding until scte-35 are found, and then return them to the caller.

I use this in the multicast example, to append my own print message to the scte objects.

This could be used in the future to handle the found scte messages in any arbitrary use, i.e. publish to a messaging queue, sending to a remote server, custom logging, etc.