### PR TITLE
(chore): simplification of golang and python

### DIFF
--- a/examples/upid/upid_custom_output.py
+++ b/examples/upid/upid_custom_output.py
@@ -1,9 +1,8 @@
+import threefive
+
 """
 Segmentation Upid Examples
 """
-
-import threefive
-
 
 ADID = (
     "/DA4AAAAAAAA///wBQb+AAAAAAAiAiBDVUVJAAAAA3//AAApPWwDDEFCQ0QwMTIzNDU2SBAAAGgCL9A="
@@ -26,9 +25,7 @@ MID = "/DA9AAAAAAAAAACABQb+0fha8wAnAiVDVUVJSAAAv3/PAAD4+mMNEQ4FTEEzMDkICAAAAAAuU
 ADS2 = "/DBUAAAAAAAA///wBQb+AAAAAAA+AjxDVUVJAAAAC3+/Di1BRFMtVVBJRDphYTg1YmJiNi01YzQzLTRiNmEtYmViYi1lZTNiMTNlYjc5OTkRAACV15uV"
 URI = "/DBZAAAAAAAA///wBQb+AAAAAABDAkFDVUVJAAAACn//AAApMuAPLXVybjp1dWlkOmFhODViYmI2LTVjNDMtNGI2YS1iZWJiLWVlM2IxM2ViNzk5ORAAAFz7UQA="
 
-dmesg = [ADS2, MID, MPU, ATSC, AIRID]
-
-ids = []
+dmesg, ids = [ADS2, MID, MPU, ATSC, AIRID], []
 
 
 def stuff(t, upid):
@@ -41,4 +38,4 @@ for m in dmesg:
     tf = threefive.Cue(m)
     tf.decode()
     tf.encode()
-    [stuff(d.segmentation_upid_type, d.segmentation_upid) for d in tf.descriptors]
+    map(lambda d: stuff(d.segmentation_upid_type, d.segmentation_upid), tf.descriptors)

--- a/go/commands.go
+++ b/go/commands.go
@@ -101,7 +101,7 @@ func (cmd *SpliceInsert) Decode(bitn *bitter.Bitn) {
 		cmd.SpliceImmediateFlag = bitn.AsBool()
 		bitn.Forward(4)
 	}
-	if cmd.ProgramSpliceFlag == true {
+	if cmd.ProgramSpliceFlag {
 		if !cmd.SpliceImmediateFlag {
 			cmd.spliceTime(bitn)
 		}
@@ -116,7 +116,7 @@ func (cmd *SpliceInsert) Decode(bitn *bitter.Bitn) {
 			cmd.spliceTime(bitn)
 		}
 	}
-	if cmd.DurationFlag == true {
+	if cmd.DurationFlag {
 		cmd.parseBreak(bitn)
 	}
 	cmd.UniqueProgramID = bitn.AsUInt64(16)

--- a/go/descriptors.go
+++ b/go/descriptors.go
@@ -194,7 +194,7 @@ func (dscptr *SegmentDscptr) decodeSegFlags(bitn *bitter.Bitn) {
 	dscptr.ProgramSegmentationFlag = bitn.AsBool()
 	dscptr.SegmentationDurationFlag = bitn.AsBool()
 	dscptr.DeliveryNotRestrictedFlag = bitn.AsBool()
-	if dscptr.DeliveryNotRestrictedFlag == false {
+	if !dscptr.DeliveryNotRestrictedFlag {
 		dscptr.WebDeliveryAllowedFlag = bitn.AsBool()
 		dscptr.NoRegionalBlackoutFlag = bitn.AsBool()
 		dscptr.ArchiveAllowedFlag = bitn.AsBool()
@@ -216,7 +216,7 @@ func (dscptr *SegmentDscptr) decodeSegCmpnts(bitn *bitter.Bitn) {
 }
 
 func (dscptr *SegmentDscptr) decodeSegmentation(bitn *bitter.Bitn) {
-	if dscptr.SegmentationDurationFlag == true {
+	if dscptr.SegmentationDurationFlag {
 		dscptr.SegmentationDuration = bitn.As90k(40)
 	}
 	dscptr.SegmentationUpidType = bitn.AsUInt8(8)

--- a/go/stream.go
+++ b/go/stream.go
@@ -74,10 +74,7 @@ func (stream *Stream) mkPts(prgm uint16) float64 {
 }
 
 func (stream *Stream) parsePusi(pkt []byte) bool {
-	if (pkt[1]>>6)&1 == 1 {
-		return true
-	}
-	return false
+	return (pkt[1]>>6)&1 == 1
 }
 
 func (stream *Stream) parsePts(pkt []byte, pid uint16) {
@@ -139,7 +136,7 @@ func (stream *Stream) chkPartial(pay []byte, pid uint16, sep []byte) []byte {
 func (stream *Stream) sameAsLast(pay []byte, pid uint16) bool {
 	val, ok := stream.last[pid]
 	if ok {
-		if bytes.Compare(pay, val) == 0 {
+		if bytes.Equal(pay, val) {
 			return true
 		}
 	}


### PR DESCRIPTION
1. Replace `bytes.Compare` with `bytes.Equal`

    Instead of using bytes.Compare to check whether two byte slices are
    equal, the shorthand bytes.Equal, specifically created for checking
    equality, could be used.

2. Simplify returning of boolean expression

    Instead of conditionally checking for the value of a boolean expression
    and then returning true or false, returning the expression itself
    simplifies the code and improves readability.

3. Expression "[stuff(d.segmentation_upid_type, d.segmentation_upid) for d in tf.descriptors]" is assigned to nothing

    Seemed odd to have list comprehension assigned to nothing. It now uses
    `map` to avoid an unassigned expression.

4. Omit comparison with boolean constant

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>