### PR TITLE
Add padding to as_hex()

### DIFF
--- a/threefive/bitn.py
+++ b/threefive/bitn.py
@@ -44,7 +44,7 @@ class BitBin:
         """
         k = self.as_int(num_bits)
         nibbles = (num_bits + 3) >> 2
-        return f"0x{k:0{nibbles}x}"
+        return "0x" + hex(k)[2:].zfill(nibbles)
 
     def as_ascii(self, num_bits):
         """

--- a/threefive/bitn.py
+++ b/threefive/bitn.py
@@ -42,7 +42,9 @@ class BitBin:
         Returns the hex value
         of num_bits of bits
         """
-        return hex(self.as_int(num_bits))
+        k = self.as_int(num_bits)
+        nibbles = (num_bits + 3) >> 2
+        return f"0x{k:0{nibbles}x}"
 
     def as_ascii(self, num_bits):
         """
@@ -61,7 +63,6 @@ class BitBin:
         Returns num_bits of bits
         as bytes decoded to as_ascii
         """
-        print(charset)
         stuff = self.as_int(num_bits)
         wide = num_bits >> 3
         return int.to_bytes(stuff, wide, byteorder="big").decode(


### PR DESCRIPTION
The current implementation of `bitn.as_hex()` removes leading zeroes, which makes some things more difficult when processing or reading its output. For example, `bytes.fromhex()` requires an even number of nibbles which is not guaranteed by `as_hex()` as the width depends on the value. Also, since hexadecimal data is a low level representation, the position of the digits is important (e.g. `0xfd` from a 16-bit field could mean `0x00fd` or `0xfd00`) and having leading zeroes clearly communicates the position and size of the data.

Therefore in this PR I propose to change `as_hex()` to always return a fixed length string regardless of value. The width is only depending on the minimum number of nibbles required to contain the number of bits read from the input.