### PR TITLE
Support PIDs having TS payload stuffing

### DIFF
--- a/threefive/stream.py
+++ b/threefive/stream.py
@@ -463,7 +463,10 @@ class Stream:
         """
         parse a scte35 cue from one or more packets
         """
-        pay = self._chk_partial(self._parse_payload(pkt), pid, self._SCTE35_TID)
+        pkt_pay = self._parse_payload(pkt)
+        if len(pkt_pay) == 0:
+            return False
+        pay = self._chk_partial(pkt_pay, pid, self._SCTE35_TID)
         if not pay:
             self.pids.scte35.remove(pid)
             return False


### PR DESCRIPTION
As soon as an empty TS packet arrives (a packet that is filled with adaptation_field only), it is removed from the list of SCTE-35 PIDs to process. It shouldn't do that because TS payload stuffing is a valid way of keeping the data flowing without sending actual payload. The PID may very well contain valid SCTE-35 data later. This PR fixes that by checking the payload length and skipping the packet if there is no payload in the TS packet.