### PR TITLE
Fixes in Examples section

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@
    * [Display SCTE35 info via Webvtt Subtitles](https://github.com/futzu/threefive/blob/master/examples/stream/cue2vtt.py)
    * [Return a list of SCTE-35 Cues from an MPEGTS file](https://github.com/futzu/threefive/blob/master/examples/stream/cue_list.py)
    * [Parsing SCTE35 from MPEGTS over HTTPS](https://github.com/futzu/threefive/blob/master/examples/stream/cool_decode_http.py)
-   * [Parsing SCTE3 from MPEGTS over HTTPS](https://github.com/futzu/threefive/blob/master/examples/stream/decode_http.py)
+   * [Parsing SCTE35 from MPEGTS over HTTPS](https://github.com/futzu/threefive/blob/master/examples/stream/decode_http.py)
    * [Stream.decode_proxy() Example](https://github.com/futzu/SCTE35-threefive/blob/master/examples/stream/decode_proxy.py)
    * [Show preroll](https://github.com/futzu/threefive/blob/master/examples/stream/preroll.py)
 
@@ -20,8 +20,8 @@
       * [HASP Hls Aes Scte-35 Parser](https://github.com/futzu/threefive/blob/master/examples/hls/hasp.py)
 
 * `Time Signal`
-  * [Time Signal Placement Opportunity End](https://github.com/futzu/threefive/blob/master/examples/timesignal/time_signal-placement_opportunity_end.py)
-  * [Time Signal Program Overlap](https://github.com/futzu/threefive/blob/master/examples/timesignal/time_signal-program_overlap.py)
+  * [Time Signal Placement Opportunity End](https://github.com/futzu/threefive/blob/master/examples/timesignal/time_signal_placement_opportunity_end.py)
+  * [Time Signal Program Overlap](https://github.com/futzu/threefive/blob/master/examples/timesignal/time_signal_program_overlap.py)
   * [Time Signal Program Start End](https://github.com/futzu/threefive/blob/master/examples/timesignal/time_signal_blackout_override_program_end.py)
 
  * `Encode`

--- a/examples/upid/upid_custom_output.py
+++ b/examples/upid/upid_custom_output.py
@@ -40,5 +40,4 @@ def stuff(t, upid):
 for m in dmesg:
     tf = threefive.Cue(m)
     tf.decode()
-    tf.encode()
     _ = [stuff(d.segmentation_upid_type, d.segmentation_upid) for d in tf.descriptors]


### PR DESCRIPTION
Just some small fixes for typos and broken links. Also `upid_custom_output.py` crashed at `tf.encode()` which I don't think is needed here.