### PR TITLE
Graceful handling of UPID errors - take 2

### DIFF
--- a/threefive/upids.py
+++ b/threefive/upids.py
@@ -31,8 +31,6 @@ class UpidDecoder:
         }
 
     def _decode_eidr(self):
-        if self.upid_length < 12:
-            raise Exception(f"upid_length is {self.upid_length} should be 12 bytes")
         pre = self.bitbin.as_int(16)
         post = []
         bit_count = 80
@@ -59,8 +57,9 @@ class UpidDecoder:
                 "upid_type": upid_type,
                 "upid_type_name": upid_type_name,
                 "upid_length": upid_length,
-                "segmentation_upid": segmentation_upid,
             }
+            if segmentation_upid is not None:
+                mid.upid["segmentation_upid"] = segmentation_upid
             ulb -= upid_length << 3
             upids.append(mid_upid)
         return upids
@@ -84,34 +83,53 @@ class UpidDecoder:
     def _decode_uri(self):
         return self.bitbin.as_charset(self.upid_length << 3, charset)
 
+    def _decode_bad(self, message):
+        bad_data = {"error_message": message}
+        if self.upid_length:
+            bad_data["bad_data"] = self.bitbin.as_hex(self.upid_length << 3)
+        return bad_data
+
+    def _chk_length(self, min, max):
+        if self.upid_length >= min and self.upid_length <= max:
+            return False
+        return f"invalid length: expected {min} .. {max} bytes"
+
     def decode(self):
         """
         decode returns a upid determined by
         self.upid_type and upid_map below.
         """
         upid_map = {
-            0x01: ["Deprecated", self._decode_uri],
-            0x02: ["Deprecated", self._decode_uri],
-            0x03: ["AdID", self._decode_uri],
-            0x04: ["UMID", self._decode_umid],
-            0x05: ["ISAN", self._decode_isan],
-            0x06: ["ISAN", self._decode_isan],
-            0x07: ["TID", self._decode_uri],
-            0x08: ["AiringID", self._decode_air_id],
-            0x09: ["ADI", self._decode_uri],
-            0x10: ["UUID", self._decode_uri],
-            0x11: ["SCR", self._decode_uri],
-            0x0A: ["EIDR", self._decode_eidr],
-            0x0B: ["ATSC", self._decode_atsc],
-            0x0C: ["MPU", self._decode_mpu],
-            0x0D: ["MID", self._decode_mid],
-            0x0E: ["ADS Info", self._decode_uri],
-            0x0F: ["URI", self._decode_uri],
-            0xFD: ["Unknown", self._decode_uri],
+            0x00: ["Not Used", self._decode_uri, 0, 0],
+            0x01: ["Deprecated", self._decode_uri, 0, 255],
+            0x02: ["Deprecated", self._decode_uri, 8, 8],
+            0x03: ["AdID", self._decode_uri, 12, 12],
+            0x04: ["UMID", self._decode_umid, 32, 32],
+            0x05: ["ISAN", self._decode_isan, 8, 8],
+            0x06: ["ISAN", self._decode_isan, 12, 12],
+            0x07: ["TID", self._decode_uri, 12, 12],
+            0x08: ["AiringID", self._decode_air_id, 8, 8],
+            0x09: ["ADI", self._decode_uri, 3, 255],
+            0x0A: ["EIDR", self._decode_eidr, 12, 12],
+            0x0B: ["ATSC", self._decode_atsc, 4, 246],
+            0x0C: ["MPU", self._decode_mpu, 4, 255],
+            0x0D: ["MID", self._decode_mid, 2, 255],
+            0x0E: ["ADS Info", self._decode_uri, 3, 255],
+            0x0F: ["URI", self._decode_uri, 1, 255],
+            0x10: ["UUID", self._decode_uri, 16, 16],
+            0x11: ["SCR", self._decode_uri, 3, 255],
+            0xFD: ["Unknown", self._decode_uri, 1, 255],
         }
         if self.upid_type not in upid_map:
             self.upid_type = 0xFD
-        return upid_map[self.upid_type][0], upid_map[self.upid_type][1]()
+
+        min = upid_map[self.upid_type][2]
+        max = upid_map[self.upid_type][3]
+        bad = self._chk_length(min, max)
+        if bad:
+            return upid_map[self.upid_type][0], self._decode_bad(bad)
+        else:
+            return upid_map[self.upid_type][0], upid_map[self.upid_type][1]()
 
 
 def upid_encoder(nbin, upid_type, upid_length, seg_upid):
@@ -130,13 +148,13 @@ def upid_encoder(nbin, upid_type, upid_length, seg_upid):
         0x07: ["TID", _encode_uri],
         0x0B: ["ATSC", _encode_atsc],
         0x09: ["ADI", _encode_uri],
-        0x10: ["UUID", _encode_uri],
-        0x11: ["SCR", _encode_uri],
         0x0A: ["EIDR", _encode_eidr],
         0x0C: ["MPU", _encode_mpu],
         0x0D: ["MID", _encode_mid],
         0x0E: ["ADS Info", _encode_uri],
         0x0F: ["URI", _encode_uri],
+        0x10: ["UUID", _encode_uri],
+        0x11: ["SCR", _encode_uri],
     }
     if upid_type in upid_map:
         upid_map[upid_type][1](nbin, seg_upid)


### PR DESCRIPTION
I unintentionally closed #56 and now I can't push new commits there so I continue in a this new PR.

Occasionally I encounter SCTE-35 streams where only the UPID is invalid, for example this one:
```
0xFC305E00000000000000FFF00506FE7E9252100048020F435545490001881F7FBF0C000100000217435545490004955E7FBF0808000000F846189FE7310101021C435545490004955F7FFF00001F41900808000000F786E70D7F3001019C96C30E
```
This currently leads to data loss, even though the other descriptors are valid and contain useful data.

With this PR I propose to add length checks for UPID parsing. This is take 2, I have incorporated the feedback I got in #56.