### PR TITLE
Fix EIDR UPID decoder

### DIFF
--- a/threefive/upids.py
+++ b/threefive/upids.py
@@ -7,6 +7,15 @@ threefive.upids
 charset = "ascii"
 
 
+def calc_EIDR_check_digit(suffix):
+    alpha = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    mod = 36
+    chk = mod // 2
+    for n in suffix:
+        chk = (alpha.index(n) + ((chk or mod) * 2) % (mod + 1)) % mod
+    return alpha[(1 - ((chk or mod) * 2) % (mod + 1)) % mod]
+
+
 class UpidDecoder:
     """
     UpidDecoder for use by the
@@ -36,8 +45,13 @@ class UpidDecoder:
         bit_count = 80
         while bit_count:
             bit_count -= 16
-            post.append(self.bitbin.as_hex(16)[2:])
-        return f"10.{pre}/{'-'.join(post)}"
+            post.append(self.bitbin.as_hex(16)[2:].upper())
+        if pre != 5240:
+            del post[2:]
+            check = ""
+        else:
+            check = "-" + calc_EIDR_check_digit("".join(post))
+        return f"10.{pre}/{'-'.join(post)}{check}"
 
     def _decode_isan(self):
         return self.bitbin.as_hex(self.upid_length << 3)


### PR DESCRIPTION
I used [python-stdnum](https://github.com/arthurdejong/python-stdnum/blob/master/stdnum/iso7064/mod_37_36.py) for the checksum algorithm. I hope you like it!

To produce correct output for all values, merging of #57 is necessary (zero padding of hex values is everywhere, look at the specs. I really don't expect compatibility issues). Without #57, a `.zfill(4)` patch is needed in `_decode_eidr()`:
```Python
post.append(self.bitbin.as_hex(16)[2:].zfill(4).upper())
```
 
When used with the [EIDR UPID example](https://github.com/futzu/scte35-threefive/blob/master/examples/upid/upid_custom_output.py) it produces the same canonical EIDR ID as in the [EIDR specification](https://eidr.org/documents/EIDR_ID_Format.pdf):

```Bash
richard@M1-Richard richard-SCTE35-threefive % python3
Python 3.9.6 (default, Sep 13 2022, 22:03:16) 
[Clang 14.0.0 (clang-1400.0.29.102)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import threefive; cue = threefive.cue.Cue("0xfc3038000000000000fffff00506fe000000000022022043554549000000037fff0000293d6c0a0c1478f85ae100b0685b8fb1c810000068a3d654"); cue.decode()
True
>>> cue.show()                                                                                                                                              {
    "info_section": {
        "table_id": "0xfc",
        "section_syntax_indicator": false,
        "private": false,
        "sap_type": "0x3",
        "sap_details": "No Sap Type",
        "section_length": 56,
        "protocol_version": 0,
        "encrypted_packet": false,
        "encryption_algorithm": 0,
        "pts_adjustment_ticks": 0,
        "pts_adjustment": 0.0,
        "cw_index": "0xff",
        "tier": "0xfff",
        "splice_command_length": 5,
        "splice_command_type": 6,
        "descriptor_loop_length": 34,
        "crc": "0x68a3d654"
    },
    "command": {
        "command_length": 5,
        "command_type": 6,
        "name": "Time Signal",
        "time_specified_flag": true,
        "pts_time": 0.0,
        "pts_time_ticks": 0
    },
    "descriptors": [
        {
            "tag": 2,
            "descriptor_length": 32,
            "name": "Segmentation Descriptor",
            "identifier": "CUEI",
            "components": [],
            "segmentation_event_id": "0x3",
            "segmentation_event_cancel_indicator": false,
            "program_segmentation_flag": true,
            "segmentation_duration_flag": true,
            "delivery_not_restricted_flag": true,
            "segmentation_duration": 30.03,
            "segmentation_duration_ticks": 2702700,
            "segmentation_message": "Program Start",
            "segmentation_upid_type": 10,
            "segmentation_upid_type_name": "EIDR",
            "segmentation_upid_length": 12,
            "segmentation_upid": "10.5240/F85A-E100-B068-5B8F-B1C8-T",
            "segmentation_type_id": 16,
            "segment_num": 0,
            "segments_expected": 0
        }
    ]
}
>>> 
```
<img width="798" alt="Screenshot 2022-10-31 at 12 19 57" src="https://user-images.githubusercontent.com/7785851/198996558-d5399991-1a37-447b-92ed-d51ef33321e5.png">

