### PR TITLE
Add UUID UPID decoder

### DIFF
--- a/threefive/bitn.py
+++ b/threefive/bitn.py
@@ -68,7 +68,7 @@ class BitBin:
             charset, errors="replace"
         )
 
-    def as_ticks(self, num_bits):
+    def as_bites(self, num_bits):
         """
         Returns num_bits of bits
         as bytes

--- a/threefive/upids.py
+++ b/threefive/upids.py
@@ -4,6 +4,9 @@ threefive/upids.py
 threefive.upids
 
 """
+from uuid import UUID
+
+
 charset = "ascii"
 
 
@@ -83,6 +86,9 @@ class UpidDecoder:
     def _decode_uri(self):
         return self.bitbin.as_charset(self.upid_length << 3, charset)
 
+    def _decode_uuid(self):
+        return UUID(bytes=self.bitbin.as_ticks(128)).urn
+
     def _decode_bad(self, message):
         bad_data = {"error_message": message}
         if self.upid_length:
@@ -116,7 +122,7 @@ class UpidDecoder:
             0x0D: ["MID", self._decode_mid, 2, 255],
             0x0E: ["ADS Info", self._decode_uri, 3, 255],
             0x0F: ["URI", self._decode_uri, 1, 255],
-            0x10: ["UUID", self._decode_uri, 16, 16],
+            0x10: ["UUID", self._decode_uuid, 16, 16],
             0x11: ["SCR", self._decode_uri, 3, 255],
             0xFD: ["Unknown", self._decode_uri, 1, 255],
         }

--- a/threefive/upids.py
+++ b/threefive/upids.py
@@ -87,7 +87,7 @@ class UpidDecoder:
         return self.bitbin.as_charset(self.upid_length << 3, charset)
 
     def _decode_uuid(self):
-        return UUID(bytes=self.bitbin.as_ticks(128)).urn
+        return UUID(bytes=self.bitbin.as_bites(128)).urn
 
     def _decode_bad(self, message):
         bad_data = {"error_message": message}
@@ -161,7 +161,7 @@ def upid_encoder(nbin, upid_type, upid_length, seg_upid):
         0x0D: ["MID", _encode_mid],
         0x0E: ["ADS Info", _encode_uri],
         0x0F: ["URI", _encode_uri],
-        0x10: ["UUID", _encode_uri],
+        0x10: ["UUID", _encode_uuid],
         0x11: ["SCR", _encode_uri],
     }
     if upid_type in upid_map:
@@ -226,3 +226,7 @@ def _encode_uri(nbin, seg_upid):
         seg_upid = seg_upid.encode()
         print(seg_upid)
         nbin.add_bites(seg_upid)
+
+
+def _encode_uuid(nbin, seg_upid):
+    nbin.add_bites(UUID(seg_upid).bytes)


### PR DESCRIPTION
Proper string representation of the [RFC 4122](https://www.rfc-editor.org/rfc/rfc4122.html) UUID:
```JSON
        {
            "tag": 2,
            "descriptor_length": 36,
            "name": "Segmentation Descriptor",
            "identifier": "CUEI",
            "components": [],
            "segmentation_event_id": "0xadbe38c6",
            "segmentation_event_cancel_indicator": false,
            "program_segmentation_flag": true,
            "segmentation_duration_flag": true,
            "delivery_not_restricted_flag": true,
            "segmentation_duration": 471.04,
            "segmentation_duration_ticks": 42393600,
            "segmentation_message": "Break Start",
            "segmentation_upid_type": 16,
            "segmentation_upid_type_name": "UUID",
            "segmentation_upid_length": 16,
            "segmentation_upid": "urn:uuid:18d4e08d-c52b-4792-b8fe-1ffb2769f156",
            "segmentation_type_id": 34,
            "segment_num": 0,
            "segments_expected": 0
        },
```