### PR TITLE
Xml dumping fixes

### DIFF
--- a/dash.md
+++ b/dash.md
@@ -19,7 +19,7 @@
 ---
 
 ### Example #1     
-* `"u23rn:scte:scte35:2013:xml"`
+* `"urn:scte:scte35:2013:xml"`
 * Text Xml of SCTE-35 SpliceInfosection converted to a Cue instance.
 
 <details><summary> Xml </summary>
@@ -261,7 +261,7 @@ print(x)  # displays xml
 ```
 
 ### Example 3
-* `"u23rn:scte:scte35:2013:xml"`
+* `"urn:scte:scte35:2013:xml"`
 * Converting a Cue instance to xml for Dash
 <details><summary> Base64 </summary>
 
@@ -308,7 +308,7 @@ print(x)   # displays xml
 ---
 
 ### Example 4
-* `"u23rn:scte:scte35:2014:xml+bin"`
+* `"urn:scte:scte35:2014:xml+bin"`
 * Converting a Cue instance to xml+binary for Dash
 <details><summary> Base64 </summary>
 

--- a/dash.md
+++ b/dash.md
@@ -27,20 +27,20 @@
 
 ```xml
 some_xml = """<Event duration="5310000">
-            <scte35:SpliceInfoSection protocolVersion="0" ptsAdjustment="183003" tier="4095">
-            <scte35:TimeSignal>
-                <scte35:SpliceTime ptsTime="3442857000"/>
-            </scte35:TimeSignal>
-            <scte35:SegmentationDescriptor segmentationEventId="1414668"
+            <SpliceInfoSection protocolVersion="0" ptsAdjustment="183003" tier="4095" xmlns="http://www.scte.org/schemas/35">
+            <TimeSignal>
+                <SpliceTime ptsTime="3442857000"/>
+            </TimeSignal>
+            <SegmentationDescriptor segmentationEventId="1414668"
                 segmentationEventCancelIndicator="false" segmentationDuration="8100000"
                 segmentationTypeId="52" segmentNum="0" segmentsExpected="0">
-            <scte35:DeliveryRestrictions webDeliveryAllowedFlag="false"
+            <DeliveryRestrictions webDeliveryAllowedFlag="false"
                 noRegionalBlackoutFlag="false" archiveAllowedFlag="false"
                 deviceRestrictions="3"/>
-            <scte35:SegmentationUpid segmentationUpidType="8"
-                segmentationUpidLength="8">0x2df3aad7</scte35:SegmentationUpid>
-            </scte35:SegmentationDescriptor>
-            </scte35:SpliceInfoSection>
+            <SegmentationUpid segmentationUpidType="8"
+                segmentationUpidLength="8">0x2df3aad7</SegmentationUpid>
+            </SegmentationDescriptor>
+            </SpliceInfoSection>
         </Event>
         """
 ```
@@ -291,16 +291,15 @@ print(x)   # displays xml
 
 
 ```xml
-<scte35:SpliceInfoSection ptsAdjustment="0" protocolVersion="None" sapType="None" sapDetails="None" tier="None">
-        <scte35:TimeSignal>
-                <scte35:SpliceTime ptsTime="11640.3343"/>
-        </scte35:TimeSignal>
-        <scte35:SegmentationDescriptor segmentationEventId="0x4800006c" segmentationEventCancelIndicator="false" segmentationEventIdComplianceIndicator="true" segmentationDuration="225.166833" segmentNum="0" segmentsExpected="0" self.SubSegmentNum="0" subSegmentsExpected="0">
-                <DeliveryRestrictions webDeliveryAllowedFlag="true" noRegionalBlackoutFlag="true" archiveAllowedFlag="true" deviceRestrictions="No Restrictions"/>
-                <segmentation_upid segmentationUpidType="8" segmentationUpidTypeName="AiringID" segmentationUpid="0x2df3aad7"/>
-        </scte35:SegmentationDescriptor>
-</scte35:SpliceInfoSection>
-
+<SpliceInfoSection ptsAdjustment="7755790832" protocolVersion="0" sapType="3" tier="0" xmlns="http://www.scte.org/schemas/35">
+   <TimeSignal>
+      <SpliceTime ptsTime="1047630087"/>
+   </TimeSignal>
+   <SegmentationDescriptor segmentationEventId="1207959660" segmentationEventCancelIndicator="false" segmentationEventIdComplianceIndicator="true" segmentationDuration="20265015" segmentNum="0" segmentsExpected="0" subSegmentNum="0" subSegmentsExpected="0">
+      <DeliveryRestrictions webDeliveryAllowedFlag="false" noRegionalBlackoutFlag="true" archiveAllowedFlag="true" deviceRestrictions="3"/>
+      <SegmentationUpid segmentationUpidType="8">0x2df3aad7</SegmentationUpid>
+   </SegmentationDescriptor>
+</SpliceInfoSection>
 ```
 
 </details>

--- a/threefive/commands.py
+++ b/threefive/commands.py
@@ -154,9 +154,9 @@ class TimeSignal(SpliceCommand):
         """
         xml return TimeSignal as an xml node
         """
-        ts = Node("scte35:TimeSignal")
+        ts = Node("TimeSignal")
         if self.has("pts_time"):
-            st = Node("scte35:SpliceTime", attrs={"pts_time": self.as_ticks(self.pts_time)})
+            st = Node("SpliceTime", attrs={"pts_time": self.as_ticks(self.pts_time)})
             ts.add_child(st)
         return ts
 
@@ -273,10 +273,10 @@ class SpliceInsert(TimeSignal):
         for k, v in si_attrs.items():
             if v is None:
                 raise ValueError(f"\033[7mSpliceInsert.{k} needs to be set\033[27m")
-        si = Node("scte35:SpliceInsert", attrs=si_attrs)
+        si = Node("SpliceInsert", attrs=si_attrs)
         if self.pts_time:
-            prgm = Node("scte35:Program")
-            st = Node("scte35:SpliceTime", attrs={"ptsTime": self.as_ticks(self.pts_time)})
+            prgm = Node("Program")
+            st = Node("SpliceTime", attrs={"ptsTime": self.as_ticks(self.pts_time)})
             prgm.add_child(st)
             si.add_child(prgm)
         if self.break_duration:
@@ -284,7 +284,7 @@ class SpliceInsert(TimeSignal):
                 "auto_return": self.break_auto_return,
                 "duration": self.as_ticks(self.break_duration),
             }
-            bd = Node("scte35:BreakDuration", attrs=bd_attrs)
+            bd = Node("BreakDuration", attrs=bd_attrs)
             si.add_child(bd)
         return si
 

--- a/threefive/cue.py
+++ b/threefive/cue.py
@@ -9,7 +9,7 @@ from .bitn import NBin
 from .base import SCTE35Base
 from .section import SpliceInfoSection
 from .commands import command_map,SpliceInsert,TimeSignal
-from .descriptors import splice_descriptor, descriptor_map, SegmentationDescriptor
+from .descriptors import splice_descriptor, descriptor_map, SegmentationDescriptor, AvailDescriptor, DtmfDescriptor, TimeDescriptor
 from .crc import crc32
 from .xml import Node, XmlParser
 
@@ -355,6 +355,18 @@ class Cue(SCTE35Base):
             segdes=SegmentationDescriptor()
             segdes.from_xml(stuff)
             self.descriptors.append(segdes)
+        if "AvailDescriptor" in stuff:
+            availdes=AvailDescriptor()
+            availdes.from_xml(stuff)
+            self.descriptors.append(availdes)
+        if "DTMFDescriptor" in stuff:
+            dtmfdes=DtmfDescriptor()
+            dtmfdes.from_xml(stuff)
+            self.descriptors.append(dtmfdes)
+        if "TimeDescriptor" in stuff:
+            timedes=TimeDescriptor()
+            timedes.from_xml(stuff)
+            self.descriptors.append(timedes)
 
     def _xml_event_signal(self,stuff):
         self.dash_data={}

--- a/threefive/cue.py
+++ b/threefive/cue.py
@@ -403,9 +403,11 @@ class Cue(SCTE35Base):
             sig_node.add_child(bin_node)
             return sig_node
         sis= self.info_section.xml()
+        sis.attrs["xmlns"] = 'http://www.scte.org/schemas/35'
         self.decode()
         if not self.command: raise Exception('\033[7mA Splice Command is Required\033[27m')
         cmd = self.command.xml()
         sis.add_child(cmd)
         for d in self.descriptors:  sis.add_child(d.xml())
+
         return sis

--- a/threefive/descriptors.py
+++ b/threefive/descriptors.py
@@ -176,6 +176,7 @@ class DtmfDescriptor(SpliceDescriptor):
     def __init__(self, bites=None):
         super().__init__(bites)
         self.name = "DTMF Descriptor"
+        self.tag = 1
         self.identifier = "CUEI"
         self.preroll = None
         self.dtmf_count = 0

--- a/threefive/descriptors.py
+++ b/threefive/descriptors.py
@@ -167,6 +167,21 @@ class AvailDescriptor(SpliceDescriptor):
         self._chk_var(int, nbin.add_int, "provider_avail_id", 32)
         return nbin.bites
 
+    def xml(self):
+        """
+        Create a Node describing the AvailDescriptor
+        """
+        ad = Node('AvailDescriptor',attrs= {"providerAvailId": self.provider_avail_id})
+        return ad
+
+
+    def from_xml(self,stuff):
+        """
+        Load an AvailDescriptor from XML
+        """
+        if "AvailDescriptor" in stuff:
+            self.load(stuff["AvailDescriptor"])
+
 
 class DtmfDescriptor(SpliceDescriptor):
     """
@@ -205,6 +220,24 @@ class DtmfDescriptor(SpliceDescriptor):
             d_c += 1
         return nbin.bites
 
+    def xml(self):
+        """
+        Create a Node describing a DTMFDescriptor
+        """
+        dd = Node('DTMFDescriptor', attrs={
+            "preroll": self.preroll,
+            "chars": ''.join(self.dtmf_chars),
+        })
+        return dd
+
+    def from_xml(self,stuff):
+        """
+        Load an DTMFDescriptor from XML
+        """
+        if "DTMFDescriptor" in stuff:
+            stuff["DTMFDescriptor"]["dtmf_chars"] = stuff["DTMFDescriptor"].pop("chars")
+            self.load(stuff["DTMFDescriptor"])
+            self.dtmf_count = len(self.dtmf_chars)
 
 class TimeDescriptor(SpliceDescriptor):
     """
@@ -238,6 +271,24 @@ class TimeDescriptor(SpliceDescriptor):
         self._chk_var(int, nbin.add_int, "tai_ns", 32)
         self._chk_var(int, nbin.add_int, "utc_offset", 16)
         return nbin.bites
+
+    def xml(self):
+        """
+        create a Node describing a TimeDescriptor
+        """
+        td = Node("TimeDescriptor", attrs={
+            "tai_seconds", self.tai_seconds,
+            "tai_ns", self.tai_ns,
+            "utc_offset", self.utc_offset,
+        })
+        return td
+
+    def from_xml(self,stuff):
+        """
+        load a TimeDescriptor from XML
+        """
+        if "TimeDescriptor" in stuff:
+            self.load(stuff["TimeDescriptor"])
 
 
 class SegmentationDescriptor(SpliceDescriptor):

--- a/threefive/section.py
+++ b/threefive/section.py
@@ -185,10 +185,9 @@ class SpliceInfoSection(SCTE35Base):
         """
         sis_attrs= {'pts_adjustment': self.as_ticks(self.pts_adjustment),
                     'protocol_version': self.protocol_version,
-                    'sap_type': self.sap_type,
-                    'sap_details':self.sap_details,
-                    'Tier':self.tier,}
-        sis=Node('scte35:SpliceInfoSection',attrs=sis_attrs)
+                    'sap_type': int(self.sap_type, 0),
+                    'tier': int(self.tier, 0),}
+        sis=Node('SpliceInfoSection',attrs=sis_attrs)
         return sis
 
     def from_xml(self,stuff):

--- a/threefive/xml.py
+++ b/threefive/xml.py
@@ -87,8 +87,8 @@ class Node:
 
         from threefive.xml import Node
 
-        ts = Node('scte35:TimeSignal')
-        st = Node('scte35:SpliceTime',attrs={'pts_time':3442857000})
+        ts = Node('TimeSignal')
+        st = Node('SpliceTime',attrs={'pts_time':3442857000})
         ts.add_child(st)
         print(ts)
     """


### PR DESCRIPTION
Attempt to fix comments from https://github.com/futzu/SCTE35_threefive/discussions/75#discussioncomment-10765232 plus a bunch of other stuff where I will continue the conversation.

Highlights:
- fixed up some validation issues around number types
- removed some (strictly) invalid attributes
- removed explicit `scte35:` namespace in node name. this is now inserted as an attribute on the SpliceInfoSection, which I don't really like but still prefer to prefixing everything
- add support for more descriptors
- fixed DTMFDescriptor in general (was missing tag)
- improved SegmentationDescriptor parsing and dumping (but still a fair way to go)

The XML now validates against the latest schema and can be parsed by a XML parser.