### PR TITLE
Ensure chars like & are escaped correctly when outputting xml.

### DIFF
--- a/threefive/xml.py
+++ b/threefive/xml.py
@@ -58,7 +58,7 @@ def val2xml(val):
         return str(val).lower()
     if isinstance(val, (int, float)):
         return str(val)
-    return val
+    return escape_special_chars(val)
 
 
 def key2xml(string):
@@ -78,6 +78,14 @@ def mk_xml_attrs(attrs):
     """
     return "".join([f' {key2xml(k)}="{val2xml(v)}"' for k, v in attrs.items()])
 
+def escape_special_chars(val):
+    if val is not None:
+        val = val.replace("&", "&amp;")
+        val = val.replace("<", "&lt;")
+        val = val.replace(">", "&gt;")
+        val = val.replace("'", "&apos;")
+        val = val.replace("\"", "&quot;")
+    return val
 
 class Node:
     """
@@ -105,7 +113,7 @@ class Node:
         self.name = name
         if ns:
             self.name = ":".join((ns, name))
-        self.value = value
+        self.value = escape_special_chars(value)
         self.attrs = attrs
         self.children = []
         self.depth = None


### PR DESCRIPTION
A few characters need to be escaped when serialised in XML, see https://www.w3.org/TR/xml/#syntax.
