### PR TITLE
Fixup XML Comments

### DIFF
--- a/threefive/cue.py
+++ b/threefive/cue.py
@@ -19,7 +19,7 @@ from .descriptors import (
     TimeDescriptor,
 )
 from .crc import crc32
-from .xml import Node, XmlParser
+from .xml import Comment, Node, XmlParser
 
 
 class Cue(SCTE35Base):
@@ -432,7 +432,7 @@ class Cue(SCTE35Base):
         sis.add_child(cmd)
         for d in self.descriptors:
             if d.tag ==2:
-                sis.add_comment(d.segmentation_message)
+                sis.add_child(Comment(d.segmentation_message))
             sis.add_child(d.xml())
 
         return sis

--- a/threefive/descriptors.py
+++ b/threefive/descriptors.py
@@ -6,7 +6,7 @@ from .bitn import BitBin
 from .base import SCTE35Base
 from .segmentation import table20, table22, dvb_table2
 from .upids import upid_map
-from .xml import Node
+from .xml import Comment, Node
 
 
 def k_by_v(adict, avalue):
@@ -486,7 +486,7 @@ class SegmentationDescriptor(SpliceDescriptor):
                 self.segmentation_duration
             )
         sd = Node("SegmentationDescriptor", attrs=sd_attrs)
-        # sd.add_comment(f'{self.segmentation_message}') # Called in cue.py
+        # sd.add_child(Comment(f'{self.segmentation_message}')) # Called in cue.py
         the_upid = self.mk_the_upid()
         the_upid.upid_value = self.segmentation_upid
         upid_node = the_upid.xml()
@@ -504,7 +504,7 @@ class SegmentationDescriptor(SpliceDescriptor):
                     },
                 )
             )
-        sd.add_comment(f'UPID: {self.segmentation_upid_type_name}')
+        sd.add_child(Comment(f'UPID: {self.segmentation_upid_type_name}'))
 
         if isinstance(upid_node, list):
             for node in upid_node:

--- a/threefive/xml.py
+++ b/threefive/xml.py
@@ -123,6 +123,10 @@ class Node:
         for child in self.children:
             child.depth = self.depth + 1
 
+    def get_indent(self):
+        tab = "   "
+        return tab * self.depth
+
     def mk(self, obj=None):
         """
         mk makes the node obj,
@@ -132,17 +136,20 @@ class Node:
         if obj is None:
             obj = self
         obj.set_depth()
-        ndent = "   " * obj.depth
-        new_attrs = mk_xml_attrs(obj.attrs)
-        rendrd = f"{ndent}<{obj.name}{new_attrs}>"
-        if obj.value:
-            return f"{rendrd}{obj.value}</{obj.name}>\n"
-        rendrd = f"{rendrd}\n"
-        for child in obj.children:
-            rendrd += obj.mk(child)
-        if obj.children:
-            return f"{rendrd}{ndent}</{obj.name}>\n"
-        return rendrd.replace(">", "/>")
+        ndent = obj.get_indent()
+        if isinstance(obj, Comment):
+            return obj.mk(obj)
+        else:
+            new_attrs = mk_xml_attrs(obj.attrs)
+            rendrd = f"{ndent}<{obj.name}{new_attrs}>"
+            if obj.value:
+                return f"{rendrd}{obj.value}</{obj.name}>\n"
+            rendrd = f"{rendrd}\n"
+            for child in obj.children:
+                rendrd += obj.mk(child)
+            if obj.children:
+                return f"{rendrd}{ndent}</{obj.name}>\n"
+            return rendrd.replace(">", "/>")
 
     def add_child(self, child):
         """
@@ -150,12 +157,13 @@ class Node:
         """
         self.children.append(child)
 
-    def add_comment(self,comment):
-        """
-        add-comment add a comment node
-        """
-        cnode = Node(f'!-- {comment} --')
-        self.add_child(cnode)
+
+class Comment(Node):
+    def mk(self, obj=None):
+        if obj is None:
+            obj = self
+        obj.set_depth()
+        return f"{obj.get_indent()}<!-- {obj.name} -->\n"
 
 
 class XmlParser:


### PR DESCRIPTION
XML Comments do not have a closing slash at the end. Including these makes the XML invalid.

This adds a new Comment Node-derived class that handles this special case but can still be used as a child of Node.

If you think it's too complex then no worries, you just need to make sure that comments are of the form `<!-- text -->` and there is no `/` at the end.