### PR TITLE
SpliceInfoSection@tier is an optional attribute - check it exists before using it

### DIFF
--- a/threefive/section.py
+++ b/threefive/section.py
@@ -200,6 +200,6 @@ class SpliceInfoSection(SCTE35Base):
         covrt = ["tier"]
         short = stuff["SpliceInfoSection"]
         for v in covrt:
-            if isinstance(short[v], int):
+            if v in short and isinstance(short[v], int):
                 short[v] = hex(short[v])
             self.load(short)


### PR DESCRIPTION
The following XML chunk causes a KeyError because SpliceInfoSection@tier is assumed to exist. The schema says it is optional, so check it is there before operating on it.
```
<SpliceInfoSection>
  <TimeSignal>
    <SpliceTime ptsTime="0"/>
  </TimeSignal>
</SpliceInfoSection>
```